### PR TITLE
Complete sieve, template pg_hba+pg_ident (restic backups compat), rspamd typos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,3 +72,26 @@ collectd_librato_api_token: "" # (optional)
 dovecot_ssl_dh_parameters_length: 4096
 dovecot_ssl_protocols: "!SSLv3 !TLSv1 !TLSv1.1 TLSv1.2"
 dovecot_ssl_cipher_list: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+
+
+postgresql_default_auth_method: "trust"
+
+# pg_hba.conf
+postgresql_pg_hba_default:
+  - { type: local, database: all, user: "{{ db_admin_username }}", address: "", method: "{{ postgresql_default_auth_method }}", comment: "" }
+  - { type: local, database: all, user: all, address: "",             method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
+  - { type: host,  database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method }}", comment: "IPv4 local connections:" }
+  - { type: host,  database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method }}", comment: "IPv6 local connections:" }
+  - { type: local, database: all, user: "{{ db_admin_username }}", address: "", method: "peer map=root_as_{{ db_admin_username }}", comment: "Local root Unix user, passwordless access" }
+  - { type: local, database: replication, user: '{{ db_admin_username }}', address: '', method: '{{ postgresql_default_auth_method }}', comment: '' }
+
+postgresql_pg_hba_passwd_hosts: []
+postgresql_pg_hba_trust_hosts: []
+postgresql_pg_hba_custom: []
+
+# pg_ident.conf
+postgresql_pg_ident:
+  - comment: "root is allowed to login as {{ db_admin_username }}"
+    mapname: "root_as_{{ db_admin_username }}"
+    system_username: "{{ db_admin_username }}"
+    pg_username: "{{ db_admin_username }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,8 @@ mail_header_privacy: 1
 mail_virtual_domains: []
 mail_virtual_users: []
 mail_virtual_aliases: []
+mail_virtual_sieves: []
+mail_sieve_max_redirects: 5
 
 # zpush
 # common_timezone is a sovereign variable

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,6 +16,9 @@
 - name: restart postfix
   service: name=postfix state=restarted
 
+- name: restart postgresql
+  service: name=postgresql state=restarted
+
 - name: restart dovecot
   service: name=dovecot state=restarted
 

--- a/tasks/dovecot.yml
+++ b/tasks/dovecot.yml
@@ -47,7 +47,6 @@
     - 15-mailboxes.conf
     - 90-antispam.conf
     - 90-plugin.conf 
-    - 90-sieve.conf
     - auth-sql.conf.ext
   notify: restart dovecot
 
@@ -59,6 +58,7 @@
     - 15-lda.conf
     - 20-imap.conf
     - 20-lmtp.conf
+    - 90-sieve.conf
   notify: restart dovecot
 
 - name: Template dovecot-sql.conf.ext

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -11,3 +11,21 @@
   become: true
   become_user: postgres
   postgresql_user: name={{ db_admin_username }} password={{ db_admin_password }} encrypted=yes
+
+- name: PostgreSQL | Update configuration (pg_hba.conf)
+  template:
+    src: pg_hba.conf.j2
+    dest: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+    owner: "postgres"
+    group: "postgres"
+    mode: 0640
+  notify: restart postgresql
+
+- name: PostgreSQL | Update configuration (pg_ident.conf)
+  template:
+    src: pg_ident.conf.j2
+    dest: "/etc/postgresql/{{ postgres_version }}/main/pg_ident.conf"
+    owner: "postgres"
+    group: "postgres"
+    mode: 0640
+  notify: restart postgresql

--- a/tasks/sieve.yml
+++ b/tasks/sieve.yml
@@ -27,3 +27,24 @@
       {% endfor %}
   with_items: "{{ mail_virtual_sieves }}"
 
+- name: "Ensure ./sieve/managesieve.sieve -> ./dovecot.sieve symlink exist"
+  file:
+    src:  "/decrypted/{{ item.domain }}/{{ item.account }}/sieve/managesieve.sieve"
+    dest: "/decrypted/{{ item.domain }}/{{ item.account }}/.dovecot.sieve"
+    owner: vmail
+    group: vmail
+    state: link
+  with_items: "{{ mail_virtual_sieves }}"
+
+- name: "(Re)compile sieve scripts"
+  command: "/usr/bin/sievec .dovecot.sieve"
+  args:
+    chdir: "/decrypted/{{ item.domain }}/{{ item.account }}/"
+  with_items: "{{ mail_virtual_sieves }}"
+
+- name: "Ensure correct ownership of .dovecot.svbin files"
+  file:
+    path: "/decrypted/{{ item.domain }}/{{ item.account }}/.dovecot.sieve"
+    owner: vmail
+    group: vmail
+  with_items: "{{ mail_virtual_sieves }}"

--- a/templates/etc_dovecot_conf.d_90-sieve.conf.j2
+++ b/templates/etc_dovecot_conf.d_90-sieve.conf.j2
@@ -1,4 +1,5 @@
 plugin {
   sieve = file:~/sieve;active=~/.dovecot.sieve
   sieve_before = /var/lib/dovecot/sieve/before.d
+  sieve_max_redirects = {{ mail_sieve_max_redirects }}
 }

--- a/templates/etc_rspamd_local.d_metrics.conf.j2
+++ b/templates/etc_rspamd_local.d_metrics.conf.j2
@@ -8,17 +8,17 @@ group "MX" {
 	symbol "MX_INVALID" {
 	  score = 0.5;
 	  description = "No connectable MX";
-	  one_shot = "true";
+	  one_shot = true;
 	}
 	symbol "MX_MISSING" {
 	  score = 2.0;
 	  description = "No MX record";
-	  one_shot = "true";
+	  one_shot = true;
 	}
 	symbol "MX_GOOD" {
 	  score = -0.01;
 	  description = "MX was ok";
-	  one_shot = "true";
+	  one_shot = true;
 	}
 }
 

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -1,0 +1,44 @@
+# {{ ansible_managed }}
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# Default:
+{% for connection in postgresql_pg_hba_default %}
+{% if connection.comment is defined %}
+# {{connection.comment}}
+{% endif %}
+{{connection.type}}  {{connection.database}}  {{connection.user}}  {{connection.address}}  {{connection.method}}
+{% endfor %}
+
+# Password hosts
+{% for host in postgresql_pg_hba_passwd_hosts %}
+host  all  all  {{host}}  password
+{% endfor %}
+
+# Trusted hosts
+{% for host in postgresql_pg_hba_trust_hosts %}
+host  all  all  {{host}}  trust
+{% endfor %}
+
+# User custom
+{% for connection in postgresql_pg_hba_custom %}
+{% if connection.comment is defined %}
+# {{connection.comment}}
+{% endif %}
+{{connection.type}}  {{connection.database}}  {{connection.user}}  {{connection.address}}  {{connection.method}}
+{% endfor %}

--- a/templates/pg_ident.conf.j2
+++ b/templates/pg_ident.conf.j2
@@ -1,0 +1,49 @@
+# {{ ansible_managed }}
+# PostgreSQL User Name Maps
+# =========================
+#
+# Refer to the PostgreSQL documentation, chapter "Client
+# Authentication" for a complete description.  A short synopsis
+# follows.
+#
+# This file controls PostgreSQL user name mapping.  It maps external
+# user names to their corresponding PostgreSQL user names.  Records
+# are of the form:
+#
+# MAPNAME  SYSTEM-USERNAME  PG-USERNAME
+#
+# (The uppercase quantities must be replaced by actual values.)
+#
+# MAPNAME is the (otherwise freely chosen) map name that was used in
+# pg_hba.conf.  SYSTEM-USERNAME is the detected user name of the
+# client.  PG-USERNAME is the requested PostgreSQL user name.  The
+# existence of a record specifies that SYSTEM-USERNAME may connect as
+# PG-USERNAME.
+#
+# If SYSTEM-USERNAME starts with a slash (/), it will be treated as a
+# regular expression.  Optionally this can contain a capture (a
+# parenthesized subexpression).  The substring matching the capture
+# will be substituted for \1 (backslash-one) if present in
+# PG-USERNAME.
+#
+# Multiple maps may be specified in this file and used by pg_hba.conf.
+#
+# No map names are defined in the default configuration.  If all
+# system user names and PostgreSQL user names are the same, you don't
+# need anything in this file.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+
+# MAPNAME       SYSTEM-USERNAME         PG-USERNAME
+{% for pg_ident in postgresql_pg_ident %}
+{% if pg_ident.comment is defined %}
+# {{ pg_ident.comment }}
+{% endif %}
+{{ pg_ident.mapname }}  {{ pg_ident.system_username }}  {{ pg_ident.pg_username }}
+{% endfor %}


### PR DESCRIPTION
This pull request:

- completes sieve setup implementation (configured via mail_virtual_sieves), 
- adds postgres pg_hba, pg_ident templating (intended for restic backups compatibility, see i.e. https://github.com/vaizard/mage-restic)
- corrects rspamd configuration typos (boolean values were typed as strings)
